### PR TITLE
fix: ConoHa DNS record name not being absolute name

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -89,7 +89,7 @@ func (p *Provider) AppendRecords(ctx context.Context, zone string, records []lib
 	}
 
 	for _, rec := range records {
-		rawRecord, err := convertToConohaDNSRecord(rec)
+		rawRecord, err := convertToConohaDNSRecord(rec, zone)
 		if err != nil {
 			return nil, err
 		}
@@ -120,7 +120,7 @@ func (p *Provider) SetRecords(ctx context.Context, zone string, records []libdns
 	}
 
 	for _, rec := range records {
-		converted, err := convertToConohaDNSRecord(rec)
+		converted, err := convertToConohaDNSRecord(rec, zone)
 		if err != nil {
 			return nil, err
 		}
@@ -163,7 +163,7 @@ func (p *Provider) DeleteRecords(ctx context.Context, zone string, records []lib
 	}
 
 	for _, rec := range records {
-		converted, err := convertToConohaDNSRecord(rec)
+		converted, err := convertToConohaDNSRecord(rec, zone)
 		if err != nil {
 			return nil, err
 		}
@@ -214,7 +214,7 @@ func convertToLibdnsRecord(rec conohaDNSRecord) (libdns.Record, error) {
 }
 
 // convertToConohaDNSRecord converts a libdns.Record into a ConoHa-compatible raw Record struct.
-func convertToConohaDNSRecord(rec libdns.Record) (conohaDNSRecord, error) {
+func convertToConohaDNSRecord(rec libdns.Record, zone string) (conohaDNSRecord, error) {
 	rr := rec.RR()
 	parsed, err := rr.Parse()
 	if err != nil {
@@ -228,21 +228,21 @@ func convertToConohaDNSRecord(rec libdns.Record) (conohaDNSRecord, error) {
 	switch r := parsed.(type) {
 	case libdns.Address:
 		return conohaDNSRecord{
-			Name: r.Name,
+			Name: libdns.AbsoluteName(r.Name, zone),
 			Type: rr.Type,
 			Data: r.IP.String(),
 			TTL:  int(r.TTL.Seconds()),
 		}, nil
 	case libdns.CNAME:
 		return conohaDNSRecord{
-			Name: r.Name,
+			Name: libdns.AbsoluteName(r.Name, zone),
 			Type: rr.Type,
 			Data: r.Target,
 			TTL:  int(r.TTL.Seconds()),
 		}, nil
 	case libdns.TXT:
 		return conohaDNSRecord{
-			Name: r.Name,
+			Name: libdns.AbsoluteName(r.Name, zone),
 			Type: rr.Type,
 			Data: r.Text,
 			TTL:  int(r.TTL.Seconds()),

--- a/provider_test.go
+++ b/provider_test.go
@@ -26,7 +26,7 @@ func TestMain(m *testing.M) {
 	zone = os.Getenv("ZONE")
 	testRecords = []libdns.Record{
 		libdns.TXT{
-			Name: "test." + zone,
+			Name: "test",
 			Text: "testval1",
 			TTL:  time.Duration(1200) * time.Second,
 		},
@@ -53,8 +53,8 @@ func cleanupRecords(t *testing.T, p *Provider, records []libdns.Record) {
 }
 
 func isSameRecord(a libdns.Record, b libdns.Record) bool {
-	rawa, _ := convertToConohaDNSRecord(a)
-	rawb, _ := convertToConohaDNSRecord(b)
+	rawa, _ := convertToConohaDNSRecord(a, zone)
+	rawb, _ := convertToConohaDNSRecord(b, zone)
 
 	// NOTE: We intentionally do not compare TTL values here.
 	// ConoHa's API does not consistently preserve or allow updates to TTL,
@@ -112,7 +112,7 @@ func TestProvider_SetProvider(t *testing.T) {
 	newTTL := 1200
 
 	for _, testRec := range testRecords {
-		rawRec, err := convertToConohaDNSRecord(testRec)
+		rawRec, err := convertToConohaDNSRecord(testRec, zone)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
ConoHa VPS Ver.3.0 API returns a 400 error ("Parameter name is Invalid") when DNS record name are not fully qualified. This was happening because record names were passed as-is without appending the zone.

In this commit:
- Ensure all record name are converted to absolute name using libdns.AbsoluteName() before being posted via the API.
- Changed test input to use a relative record name ("test") instead of a fully qualified name ("test.\<zone\>") in `provider_test.go`
- Verified that the modified test passes, confirming the record name is correctly converted and accepted by ConoHa API.